### PR TITLE
Keep unmodified upstream files in sync with ASpace #3

### DIFF
--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -1,0 +1,49 @@
+name: Diff with upstream stylesheets
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+
+jobs:
+  diff:
+    runs-on: ubuntu-latest
+    env:
+      PROD_ARCHIVESSPACE_VERSION: v4.1.0
+    continue-on-error: true
+    strategy:
+      matrix:
+        archivesspace_version: [v4.1.0, v4.1.1]
+    steps:
+
+    - name: Checkout our custom stylesheets
+      uses: actions/checkout@v4
+      with:
+        path: ours
+
+    - name: Checkout core stylesheets
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ matrix.archivesspace_version }}
+        repository: Smithsonian/archivesspace
+        path: theirs
+        sparse-checkout: |
+          stylesheets
+
+    - name: Diff with theirs
+      id: changes
+      run: |
+        echo "changes=$(diff -qr ${{ github.workspace }}/ours/ ${{ github.workspace }}/theirs/stylesheets -X ${{ github.workspace }}/ours/overridden_files.txt)" > $GITHUB_OUTPUT
+
+    - name: Diffs match
+      if: ${{ steps.changes.outputs.changes == '' }}
+      run: |
+        echo "All core stylesheets match ArchivesSpace ${{ matrix.archivesspace_version }}."
+
+    - name: Diffs do not match
+      if: ${{ steps.changes.outputs.changes != '' }}
+      run: |
+        echo "Some stylesheets are out of sync with those in core ArchivesSpace ${{ matrix.archivesspace_version }}.  See:"
+        echo "${{ steps.changes.outputs.changes }}"
+        exit 1

--- a/as-ead-html.xsl
+++ b/as-ead-html.xsl
@@ -22,7 +22,6 @@
         *                                                                 *
         *******************************************************************
     -->
-    <!-- New temporary comment -->
     <xsl:output indent="yes" method="xml" 
         doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"  
         doctype-public="-//W3C//DTD XHTML 1.0 Strict//EN"

--- a/as-ead-html.xsl
+++ b/as-ead-html.xsl
@@ -22,6 +22,7 @@
         *                                                                 *
         *******************************************************************
     -->
+    <!-- New temporary comment -->
     <xsl:output indent="yes" method="xml" 
         doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"  
         doctype-public="-//W3C//DTD XHTML 1.0 Strict//EN"

--- a/overridden_files.txt
+++ b/overridden_files.txt
@@ -1,0 +1,11 @@
+# custom SI files
+.*
+ASpaceCleanup.xsl
+ASpacePreprocess.xsl
+ead_components.xsl
+logos
+overridden_files.*
+README.*
+# overridden files
+as-ead-pdf.xsl
+fop-config.xml


### PR DESCRIPTION
## Description
<!--- Describe your changes.  Why is this required?  What problem does it solve?  What functionality does it extend? -->
Just a little gh action to warn us if something changes in the upstream aspace stylesheets in current/future releases are ArchivesSpace.  Since we're going to be pulling in this repo whole sail into our installations, we want to be sure that the stylesheets we haven't modified remain in sync.

We'll likely want to add more later to actually diff changes for the stylesheets we *have* modified, but since that entire process is in flux right now with the EDAN/SOVA pipeline rewrite, now is not the time for that heavy lifting.  Ultimately, we may end up having far fewer customizations at the end of this process.

## Related GitHub Issue
<!--- Please link to GitHub Issue here: -->
#3 

## Testing
<!--- Please describe, in detail, how you tested your changes. -->
N/A

## Screenshot(s):
<!--- Optional screenshots of changes if relevant and helpful to reviewers -->
N/A

## Checklist

- [x] ✔️ Have you assigned at least one reviewer?
- [x] 🔗 Have you referenced any issues this PR will close?
- [x] ⬇️ Have you merged the latest upstream changes into your branch? 
- [ ] 🧪 Have you added tests to cover these changes?  If not, why:
N/A
- [ ] 🤖 Have automated checks (if any) passed?  If not, please explain for the reviewer:
Three separate commits added to show that checks pass (everything in sync with core aspace), checks fail (we modified one of the upstream files), and checks pass again (we undid those modifications).
- [x] 📘 Have you updated/added any relevant readmes/comments in the codebase?
- [x] 📚 Have you updated/added any external documentation (e.g. Confluence)?
