### PR TITLE
remove problematic h4 keep-with attribute that was applied to all sub…

### DIFF
--- a/as-ead-pdf.xsl
+++ b/as-ead-pdf.xsl
@@ -1346,8 +1346,7 @@
 						
 						<!-- heading subseries section -->
 						<xsl:if test="@level='subseries'">
-							<fo:block space-before="5mm" space-after="2mm" id="{@id}"
-								xsl:use-attribute-sets="h4">
+							<fo:block id="{@id}" xsl:use-attribute-sets="h4-subseries">
 								<xsl:apply-templates select="ead:did/ead:head" mode="step2_pdf"/>
 								<xsl:call-template name="dscSection_unitid"/>
 								<xsl:call-template name="combine-that-title-and-date"/>
@@ -2352,6 +2351,13 @@
 			<xsl:attribute name="space-after">5pt</xsl:attribute>
 			<xsl:attribute name="keep-with-next.within-page">always</xsl:attribute>
 		</xsl:attribute-set>-->
+	</xsl:attribute-set>
+	<xsl:attribute-set name="h4-subseries">
+		<xsl:attribute name="font-size">12pt</xsl:attribute>
+		<xsl:attribute name="margin-bottom">4pt</xsl:attribute>
+		<xsl:attribute name="padding-bottom">0</xsl:attribute>
+		<xsl:attribute name="space-before">5mm</xsl:attribute>
+		<xsl:attribute name="space-after">2mm</xsl:attribute>
 	</xsl:attribute-set>
 	<xsl:attribute-set name="h5">
 		<xsl:attribute name="font-size">10pt</xsl:attribute>


### PR DESCRIPTION
…series, which caused problems with NMAI.AC.379 collection guide. still need to review the utility of the other keep-with attributes

## Description
<!--- Describe your changes.  Why is this required?  What problem does it solve?  What functionality does it extend? -->
Temporary fix to remove the problematic keep-with FOP attribute that was being applied to all subseries.  For more on keeps (and breaks), see https://www.w3.org/TR/xsl11/#keepbreak 

Note:  rather than focus on this current PDF process, we will eventually replace this with another PDF process that does not include this issue to begin with.

## Related GitHub Issue
<!--- Please link to GitHub Issue here: -->
https://github.com/Smithsonian/caas-aspace-deployment/issues/248

## Testing
<!--- Please describe, in detail, how you tested your changes. -->

## Screenshot(s):
<!--- Optional screenshots of changes if relevant and helpful to reviewers -->

## Checklist

- [x] ✔️ Have you assigned at least one reviewer?
- [ ] 🔗 Have you referenced any issues this PR will close?
- [ ] ⬇️ Have you merged the latest upstream changes into your branch? 
- [ ] 🧪 Have you added tests to cover these changes?  If not, why:

- [ ] 🤖 Have automated checks (if any) passed?  If not, please explain for the reviewer:

- [ ] 📘 Have you updated/added any relevant readmes/comments in the codebase?
- [ ] 📚 Have you updated/added any external documentation (e.g. Confluence)?
