### PR TITLE
switch from text to nodes to keep those italics around

### DIFF
--- a/as-ead-pdf.xsl
+++ b/as-ead-pdf.xsl
@@ -1569,7 +1569,7 @@
 								<!-- <xsl:call-template name="combine-that-title-and-date"/> -->
 								<xsl:choose>
 									<xsl:when test="ead:did/ead:dao[2] or ead:dao[2] or ead:did/ead:daogrp[2]">
-										<xsl:value-of select="$title-and-date"/>
+										<xsl:copy-of select="$title-and-date"/>
 									</xsl:when>
 									<xsl:when
 										test="
@@ -1581,7 +1581,7 @@
 										<fo:inline xsl:use-attribute-sets="link">
 											<fo:basic-link
 												external-destination="url('{ead:did/ead:dao[1]/@*:href}')">
-												<xsl:value-of select="$title-and-date"/>
+												<xsl:copy-of select="$title-and-date"/>
 											</fo:basic-link>
 										</fo:inline>
 									</xsl:when>
@@ -1593,12 +1593,12 @@
 										">
 										<fo:inline xsl:use-attribute-sets="link">
 											<fo:basic-link external-destination="url('{ead:did/ead:daogrp[1]/ead:daoloc[@xlink:role eq 'web-resource-link'][1]/@xlink:href}')">
-												<xsl:value-of select="$title-and-date"/>
+												<xsl:copy-of select="$title-and-date"/>
 											</fo:basic-link>
 										</fo:inline>
 									</xsl:when>
 									<xsl:otherwise>
-										<xsl:value-of select="$title-and-date"/>
+										<xsl:copy-of select="$title-and-date"/>
 									</xsl:otherwise>
 								</xsl:choose>
 							</fo:block>
@@ -1651,8 +1651,8 @@
 															or normalize-space(translate(ead:daodesc/ead:p, '.,:;[]', ' ')) = normalize-space(translate($title-and-date, '.,:;[]', ' ')))">
 												<xsl:call-template name="digital_content_type"/>
 												<xsl:text>: </xsl:text>
-												<xsl:value-of
-												select="ead:daodesc/ead:p/normalize-space()"/>
+												<xsl:apply-templates
+												select="ead:daodesc/ead:p"/>
 												</xsl:if>
 												</fo:basic-link>
 											</fo:block>
@@ -1696,8 +1696,8 @@
 														not(normalize-space(translate(ead:daodesc/ead:p, '.,:;[]', ' ')) = normalize-space(translate($title, '.,:;[]', ' '))
 														or normalize-space(translate(ead:daodesc/ead:p, '.,:;[]', ' ')) = normalize-space(translate($title-and-date, '.,:;[]', ' ')))">
 														<xsl:text>Digital Content: </xsl:text>
-														<xsl:value-of
-															select="ead:daodesc/ead:p/normalize-space()"/>
+														<xsl:apply-templates
+															select="ead:daodesc/ead:p"/>
 													</xsl:if>
 												</fo:basic-link>
 											</fo:block>
@@ -1937,6 +1937,11 @@
 			<xsl:text>, </xsl:text>
 		</xsl:if>
 	</xsl:template>
+	
+	<!-- new, but possibly not needed -->
+	<xsl:template match="ead:unittitle" mode="step2_pdf" >
+		<xsl:apply-templates mode="step2_pdf"/>
+	</xsl:template>
 
 	<xsl:template name="container_details">
 		<!-- formats grouped containers. set group terms and fo:block details prior to call-template -->		
@@ -2001,7 +2006,7 @@
 					
 					<xsl:otherwise>
 						<xsl:text>: </xsl:text>
-						<xsl:value-of select="ead:daodesc/ead:p/normalize-space()"/>
+						<xsl:apply-templates select="ead:daodesc/ead:p"/>
 					</xsl:otherwise>
 				</xsl:choose>
 			</fo:basic-link>
@@ -2043,7 +2048,7 @@
 					
 					<xsl:otherwise>
 						<xsl:text>: </xsl:text>
-						<xsl:value-of select="ead:daodesc/ead:p/normalize-space()"/>
+						<xsl:apply-templates select="ead:daodesc/ead:p"/>
 					</xsl:otherwise>
 				</xsl:choose>
 			</fo:basic-link>


### PR DESCRIPTION
## Description
<!--- Describe your changes.  Why is this required?  What problem does it solve?  What functionality does it extend? -->
Previously, the process relied upon "value-of select" when grabbing the titles for the PDF display.  This is a fundamental problem, though, since that results in a pure text node, with no formatting handled over.  This update fixes that issue by using "copy-of select", which was the original intention (since that process will return formatting elements needed to apply italics further downstream).

## Related GitHub Issue
<!--- Please link to GitHub Issue here: -->
https://github.com/Smithsonian/caas_aspace_stylesheets/issues/24

## Testing
<!--- Please describe, in detail, how you tested your changes. -->

## Screenshot(s):
<!--- Optional screenshots of changes if relevant and helpful to reviewers -->

## Checklist

- [x ] ✔️ Have you assigned at least one reviewer?
- [x ] 🔗 Have you referenced any issues this PR will close?
- [x ] ⬇️ Have you merged the latest upstream changes into your branch? 
- [ ] 🧪 Have you added tests to cover these changes?  If not, why:
We do not currently use https://github.com/xspec/xspec/wiki/What-is-XSpec (but we should).  I have tested the process, though, and I also added an extra template for the PDF processing step which was previously missing for "unit title".  This might not be needed, but it certainly won't hurt anything.  

- [x ] 🤖 Have automated checks (if any) passed?  If not, please explain for the reviewer:

- [ ] 📘 Have you updated/added any relevant readmes/comments in the codebase?
- [ ] 📚 Have you updated/added any external documentation (e.g. Confluence)?
