### PR TITLE
add ASpaceExtents file to overridden_files config text file

### DIFF
--- a/as-ead-pdf.xsl
+++ b/as-ead-pdf.xsl
@@ -459,25 +459,24 @@
 								</xsl:otherwise>
 							</xsl:choose>
 						</fo:bookmark-title>
+						<!-- Creates a submenu for subfonds, subgrp or subseries -->
+						<xsl:for-each select="child::*[@level = 'subfonds'] | child::*[@level = 'subgrp']  | child::*[@level = 'subseries']">
+							<fo:bookmark internal-destination="{local:buildID(.)}">
+								<fo:bookmark-title>
+									<xsl:choose>
+										<xsl:when test="ead:head">
+											<xsl:apply-templates select="child::*/ead:head" mode="step2_pdf"/>
+										</xsl:when>
+										<xsl:otherwise>
+											<xsl:value-of select="string-join((local:capitalize-first-word(@level), ead:did/ead:unitid[not(@audience='internal')]), ' ')"/>
+											<xsl:text>: </xsl:text>
+											<xsl:value-of select="ead:did/ead:unittitle"/>
+										</xsl:otherwise>
+									</xsl:choose>
+								</fo:bookmark-title>
+							</fo:bookmark>
+						</xsl:for-each>
 					</fo:bookmark>
-					<!-- Creates a submenu for subfonds, subgrp or subseries -->
-					<xsl:for-each select="child::*[@level = 'subfonds'] | child::*[@level = 'subgrp']  | child::*[@level = 'subseries']">
-						<fo:bookmark internal-destination="{local:buildID(.)}">
-							<fo:bookmark-title>
-								<xsl:choose>
-									<xsl:when test="ead:head">
-										<xsl:apply-templates select="child::*/ead:head" mode="step2_pdf"/>
-									</xsl:when>
-									<xsl:otherwise>
-										<xsl:value-of select="local:capitalize-first-word(@level)"/>
-										<xsl:value-of select="ead:did/ead:unitid[not(@audience='internal')]"/>
-										<xsl:text>: </xsl:text>
-										<xsl:value-of select="ead:did/ead:unittitle"/>
-									</xsl:otherwise>
-								</xsl:choose>
-							</fo:bookmark-title>
-						</fo:bookmark>
-					</xsl:for-each>
 				</xsl:for-each>
 			</xsl:for-each>
 		</fo:bookmark-tree>

--- a/overridden_files.txt
+++ b/overridden_files.txt
@@ -1,6 +1,7 @@
 # custom SI files
 .*
 ASpaceCleanup.xsl
+ASpaceExtents.xsl
 ASpacePreprocess.xsl
 ead_components.xsl
 logos


### PR DESCRIPTION
## Description
<!--- Describe your changes.  Why is this required?  What problem does it solve?  What functionality does it extend? -->
To get future tests to pass, this final commit on this branch adds the `ASpaceExtents.xsl` file to the overridden_files.txt configuration file.

## Related GitHub Issue
<!--- Please link to GitHub Issue here: -->

## Testing
<!--- Please describe, in detail, how you tested your changes. -->

## Screenshot(s):
<!--- Optional screenshots of changes if relevant and helpful to reviewers -->

## Checklist

- [ ] ✔️ Have you assigned at least one reviewer?
- [ ] 🔗 Have you referenced any issues this PR will close?
- [ ] ⬇️ Have you merged the latest upstream changes into your branch? 
- [ ] 🧪 Have you added tests to cover these changes?  If not, why:

- [ ] 🤖 Have automated checks (if any) passed?  If not, please explain for the reviewer:

- [ ] 📘 Have you updated/added any relevant readmes/comments in the codebase?
- [ ] 📚 Have you updated/added any external documentation (e.g. Confluence)?
